### PR TITLE
Update Nix package inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750173260,
-        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
+        "lastModified": 1770165109,
+        "narHash": "sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
+        "rev": "b027ee29d959fda4b60b57566d64c98a202e0feb",
         "type": "github"
       },
       "original": {
@@ -24,16 +24,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1749511373,
-        "narHash": "sha256-7u1TdHQaUCzzgf/n8T3bQosuYXyNBEPU/3WQQqozE5o=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "7b4ef99fed96966269ee35994407fa4c06097a4d",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.5.6",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751313918,
-        "narHash": "sha256-HsJM3XLa43WpG+665aGEh8iS8AfEwOIQWk3Mke3e7nk=",
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e04a388232d9a6ba56967ce5b53a8a6f713cdfcf",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
         "type": "github"
       },
       "original": {
@@ -81,38 +81,20 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gallatin": {
       "flake": false,
       "locked": {
-        "lastModified": 1756597534,
-        "narHash": "sha256-zdbypIcZr83jpQPD8v6sO2peFvZmMH/+FzZc79qX33E=",
+        "lastModified": 1768020969,
+        "narHash": "sha256-rRaB5M2nAtau5KjQQ3FLzkx8ARyzHIQHy/ciuryYauI=",
         "owner": "junr03",
         "repo": "gallatin",
-        "rev": "65586479c7d30306d7e43903e68737be905c3dcc",
+        "rev": "7281e93b508c432fc2e83aa1c5250fe5ee92f8c9",
         "type": "github"
       },
       "original": {
         "owner": "junr03",
-        "ref": "main",
         "repo": "gallatin",
+        "rev": "7281e93b508c432fc2e83aa1c5250fe5ee92f8c9",
         "type": "github"
       }
     },
@@ -142,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1752062782,
-        "narHash": "sha256-Dod77HcIByOyfGLEJOgRxg2Fmk2Y5lVgMEcN/xVEt/8=",
+        "lastModified": 1783479733,
+        "narHash": "sha256-d/JatqgG+Pmo+IuCTZfnrEAPWU3fdha48GQeXuFO+bE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bec8ff39811568eb7c8c8d1e2a1a476326748f51",
+        "rev": "cee3f0e7fec85d80c149c7afc29926747f7bd3c2",
         "type": "github"
       },
       "original": {
@@ -174,11 +156,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1752067514,
-        "narHash": "sha256-42Cf43+Krk5OljBmXyqkwcswzIJikYlfX5vcAJWut3Y=",
+        "lastModified": 1783479655,
+        "narHash": "sha256-65WnYcBwAbHbX1B8hfuoDuCKcH14abXLL7vlL5as5tM=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "c16d6f44665b84242a759b13b1eb604dddf57f40",
+        "rev": "1ec5ff82aba579775972c160dc9c88f594c8d488",
         "type": "github"
       },
       "original": {
@@ -190,11 +172,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1752067806,
-        "narHash": "sha256-nyJ1NM7ZFclLgb/8rYM8XXOMSic4/d14X+vAjEb+L+0=",
+        "lastModified": 1783483219,
+        "narHash": "sha256-R0Jpi84ZGFLdHvVnrFARu2TI2GpYKGoN51sf8VdpJPQ=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "e3aeae98f7333e6277dcec0163e31497a7c251a1",
+        "rev": "b0df8373dbd5742c918c5677e9236490f4c5a588",
         "type": "github"
       },
       "original": {
@@ -208,11 +190,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1749952250,
-        "narHash": "sha256-V2ix0knpdJXirQ+4pjbnggjdSALTsFWGIP/NDpaQkdU=",
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "37126f06f4890f019af3d7606ce5d30a457afcd0",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
         "type": "github"
       },
       "original": {
@@ -223,15 +205,14 @@
     },
     "nix-vscode-extensions": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1752026977,
-        "narHash": "sha256-Rfd90Ghp/Z1B1xwi01YGvahwqQ7Y/kIu1sqzo8O1Myc=",
+        "lastModified": 1783480916,
+        "narHash": "sha256-+n7JzI4UyIW9G0moGbxo7csrvrh+gKkKc6src9UeKwk=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "6b1fe15b18ed4170da1e24746717639f992b9cb7",
+        "rev": "64e46804f27b274729293d033f3361710dea3438",
         "type": "github"
       },
       "original": {
@@ -242,59 +223,59 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745391562,
-        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "lastModified": 1754028485,
+        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751637120,
-        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
+        "lastModified": 1782948114,
+        "narHash": "sha256-AXmz9ho4Lud5CsbrZsuSVwpQZ4o5FgZ1chxBn5cJ8+0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
+        "rev": "9e92285f211dad236540fd617d7e30e0b99bc0e1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
-        "owner": "NixOS",
+        "lastModified": 1777207419,
+        "narHash": "sha256-V3bmPWAajDiC+1ClDOp55gianW2EyRJSJOyu1RUQibc=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "a7ecea3deccfbdbf22945a89984fcc5a169da8aa",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "a7ecea3deccfbdbf22945a89984fcc5a169da8aa",
         "type": "github"
       }
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1751792365,
-        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -326,11 +307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760409263,
-        "narHash": "sha256-GvcdHmY3nZnU6GnUkEG1a7pDZPgFcuN+zGv3OgvfPH0=",
+        "lastModified": 1783404876,
+        "narHash": "sha256-DAh1CfiRVwr8Szkj5PiHmsqh10NHPb8SKPx7w/B+l9E=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5694018463c2134e2369996b38deed41b1b9afc1",
+        "rev": "3c161f20193bd91a73913b417e5b06d41860336d",
         "type": "github"
       },
       "original": {
@@ -340,21 +321,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/modules/host.nix
+++ b/modules/host.nix
@@ -8,6 +8,32 @@
 let
   user = "junr03";
   nfsServer = "100.81.172.57";
+  photosMountScript = ''
+    set -u
+
+    /bin/mkdir -p /Volumes/photos/raw /Volumes/photos/edited
+    failures=0
+
+    mount_if_missing() {
+      remote="$1"
+      mountpoint="$2"
+
+      if /sbin/mount | /usr/bin/grep -q " on $mountpoint "; then
+        echo "$mountpoint is already mounted"
+        return 0
+      fi
+
+      echo "Mounting $remote at $mountpoint"
+      if ! /sbin/mount_nfs -o vers=3,resvport,nosuid,nolock "$remote" "$mountpoint"; then
+        echo "Failed to mount $remote at $mountpoint" >&2
+        failures=1
+      fi
+    }
+
+    mount_if_missing "${nfsServer}:/photos/raw" /Volumes/photos/raw
+    mount_if_missing "${nfsServer}:/photos/edited" /Volumes/photos/edited
+    exit "$failures"
+  '';
 in
 {
   imports = [
@@ -63,22 +89,6 @@ in
     fira-code
     nerd-fonts.fira-code
   ];
-
-  # Explicitly manage autofs master and a dedicated direct map to ensure mounts are active.
-  # This avoids depending on the system's "-static" entry which may not be present on all hosts.
-  environment.etc."auto_master".text = ''
-    # Automounter master map
-    +auto_master            # Use DirectoryService-managed entries if present
-    /net    -hosts         -nobrowse,hidefromfinder,nosuid
-    /home   auto_home      -nobrowse,hidefromfinder
-    /Network/Servers       -fstab
-    /-      auto_photos    -nosuid
-  '';
-
-  environment.etc."auto_photos".text = ''
-    /Volumes/photos/raw    -fstype=nfs,vers=3,resvport,nosuid,nolock     ${nfsServer}:/photos/raw
-    /Volumes/photos/edited -fstype=nfs,vers=3,resvport,nosuid,nolock     ${nfsServer}:/photos/edited
-  '';
 
   # System activation scripts
   system.activationScripts = {
@@ -141,19 +151,10 @@ in
     };
   };
 
-  # Create mount points and refresh autofs at activation/boot
+  # Create mount points and try to mount immediately during activation.
   system.activationScripts.nfsMounts = {
     text = ''
-      set -euo pipefail
-      echo "Ensuring NFS mount points exist"
-      /bin/mkdir -p /Volumes/photos /Volumes/photos/raw /Volumes/photos/edited
-
-      echo "[nfsAutofs] Reloading automount maps"
-      /usr/sbin/automount -vc || true
-
-      echo "[nfsAutofs] Touching paths to trigger mounts"
-      /bin/ls -1 /Volumes/photos/raw >/dev/null 2>&1 || true
-      /bin/ls -1 /Volumes/photos/edited >/dev/null 2>&1 || true
+      ${photosMountScript} || true
     '';
     deps = [
       "users"
@@ -161,29 +162,21 @@ in
     ];
   };
 
-  # Keep mounts pinned: lightweight LaunchDaemon that periodically touches them
-  launchd.daemons."photos-nfs-pin" = {
+  # Mount the photo shares at boot and retry periodically for network changes.
+  launchd.daemons."photos-nfs-mount" = {
     script = ''
-      #! /bin/sh
-      set -euo pipefail
-      /bin/mkdir -p /Volumes/photos /Volumes/photos/raw /Volumes/photos/edited
-      while true; do
-        # Touch inside the directories to trigger autofs mounts if needed
-        /bin/ls -1 /Volumes/photos/raw >/dev/null 2>&1 || true
-        /bin/ls -1 /Volumes/photos/edited >/dev/null 2>&1 || true
-        /bin/sleep 60
-      done
+      ${photosMountScript}
     '';
     serviceConfig = {
-      Label = "net.electricpeak.photos-nfs-pin";
+      Label = "net.electricpeak.photos-nfs-mount";
       RunAtLoad = true;
+      StartInterval = 60;
       KeepAlive = {
-        SuccessfulExit = false;
         NetworkState = true;
       };
       ProcessType = "Background";
-      StandardOutPath = "/var/log/photos-nfs-pin.log";
-      StandardErrorPath = "/var/log/photos-nfs-pin.err.log";
+      StandardOutPath = "/var/log/photos-nfs-mount.log";
+      StandardErrorPath = "/var/log/photos-nfs-mount.err.log";
     };
   };
 }

--- a/modules/host.nix
+++ b/modules/host.nix
@@ -154,7 +154,9 @@ in
   # Create mount points and try to mount immediately during activation.
   system.activationScripts.nfsMounts = {
     text = ''
-      ${photosMountScript} || true
+      (
+        ${photosMountScript}
+      ) || true
     '';
     deps = [
       "users"

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -9,7 +9,7 @@ with pkgs;
   btop
   coreutils
   killall
-  neofetch
+  fastfetch
   openssh
   sqlite
   wget
@@ -32,12 +32,11 @@ with pkgs;
   font-awesome
   hack-font
   noto-fonts
-  noto-fonts-emoji
+  noto-fonts-color-emoji
   meslo-lgs-nf
 
   # Node.js development tools
-  nodePackages.npm # globally install npm
-  nodePackages.prettier
+  prettier
   nodejs
 
   # Text and terminal utilities


### PR DESCRIPTION
## Summary

- update the flake lockfile inputs
- replace deprecated/renamed packages in the shared package list
- use `fastfetch`, `noto-fonts-color-emoji`, and top-level `prettier`

## Validation

- Not run, per request to commit, push, and create the PR without further checks.