### PR TITLE
Clean up package configuration

### DIFF
--- a/modules/brews.nix
+++ b/modules/brews.nix
@@ -1,4 +1,3 @@
 _: [
-  "colima"
   "ykman"
 ]

--- a/modules/casks.nix
+++ b/modules/casks.nix
@@ -3,9 +3,7 @@ _: [
   "ghostty"
 
   # Communication Tools
-  "discord"
   "microsoft-excel"
-  "microsoft-outlook"
   "microsoft-powerpoint"
   "microsoft-teams"
   "microsoft-word"
@@ -13,20 +11,7 @@ _: [
   "zoom"
 
   # Utility Tools
-  "loop"
   "tailscale"
   "yubico-authenticator"
   "yubico-yubikey-manager"
-
-  # Entertainment Tools
-  "spotify"
-
-  # Productivity Tools
-  "shapr3d"
-
-  # Browsers
-  "firefox"
-
-  # Creative Tools
-  "inkscape"
 ]

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -58,7 +58,6 @@ in
       {
         home = {
           enableNixpkgsReleaseCheck = false;
-          packages = pkgs.callPackage ./packages.nix { };
           file = userFiles;
           stateVersion = "23.11";
         };
@@ -81,9 +80,6 @@ in
             ];
             shellAliases = {
               ll = "ls -lh --color=auto";
-
-              # Use ripgrep for searching
-              search = "rg -p --glob '!node_modules/*' \\\$@";
 
               # Use difftastic for diffing
               diff = "difft";
@@ -112,9 +108,6 @@ in
 
               # Remove history data we don't want to see
               export HISTIGNORE="pwd:ls:cd"
-
-              # Ripgrep alias
-              alias search=rg -p --glob '!node_modules/*'  $@
 
               # code is my editor
               export ALTERNATE_EDITOR=""

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -2,14 +2,9 @@
 with pkgs;
 [
   # General packages for development and system management
-  aspell
-  aspellDicts.en
   bash-completion
-  bat
-  btop
   coreutils
   killall
-  neofetch
   openssh
   sqlite
   wget
@@ -30,9 +25,6 @@ with pkgs;
   fira-code
   nerd-fonts.fira-code
   font-awesome
-  hack-font
-  noto-fonts
-  noto-fonts-emoji
   meslo-lgs-nf
 
   # Node.js development tools
@@ -41,15 +33,7 @@ with pkgs;
   nodejs
 
   # Text and terminal utilities
-  htop
-  hunspell
-  iftop
-  jq
-  ripgrep
-  tree
   tmux
-  unrar
-  unzip
   zsh-powerlevel10k
   nixfmt-rfc-style
 


### PR DESCRIPTION
## Summary

- remove duplicate installation of `modules/packages.nix` through Home Manager
- prune requested Nix packages, Homebrew formulae, and casks
- remove shell aliases that referenced `rg` after removing `ripgrep`

## Validation

- scanned `modules/` for removed package names and leftover `rg` alias references
- ran targeted `nix eval --no-write-lock-file` checks for Homebrew formulae, casks, and Home Manager packages

Note: Nix reports that the `gallatin` input in `flake.nix` wants a newer lock entry, but this PR intentionally does not update `flake.lock`.