### PR TITLE
Support a locally configured primary user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.blacktail.local

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Configuration for provisioning macOS machines with [Nix](https://nixos.org), [`n
    cd blacktail
    ```
 
+1. **Set this Mac's primary user**
+
+   Blacktail needs the macOS short username for the account it will manage. Create the local configuration with your current username:
+
+   ```sh
+   printf 'BLACKTAIL_PRIMARY_USER=%s\n' "$(id -un)" > .blacktail.local
+   ```
+
+   If you are provisioning another account, replace `$(id -un)` with that account's short username. Git ignores `.blacktail.local`, and the build commands load it automatically.
+
 1. **Build and activate the system**
 
    ```sh

--- a/apps/build
+++ b/apps/build
@@ -8,10 +8,15 @@ NC='\033[0m'
 SYSTEM_TYPE="aarch64-darwin"
 FLAKE_SYSTEM="darwinConfigurations.${SYSTEM_TYPE}.system"
 
+if [ -z "${BLACKTAIL_PRIMARY_USER:-}" ] && [ -f ./.blacktail.local ]; then
+  . ./.blacktail.local
+fi
+export BLACKTAIL_PRIMARY_USER
+
 export NIXPKGS_ALLOW_UNFREE=1
 
 echo "${YELLOW}Starting build...${NC}"
-nix --extra-experimental-features 'nix-command flakes' build .#$FLAKE_SYSTEM $@
+nix --extra-experimental-features 'nix-command flakes' build --impure .#$FLAKE_SYSTEM "$@"
 
 echo "${YELLOW}Cleaning up...${NC}"
 unlink ./result

--- a/apps/build-switch
+++ b/apps/build-switch
@@ -8,14 +8,20 @@ NC='\033[0m'
 SYSTEM_TYPE="aarch64-darwin"
 FLAKE_SYSTEM="darwinConfigurations.${SYSTEM_TYPE}.system"
 
+if [ -z "${BLACKTAIL_PRIMARY_USER:-}" ] && [ -f ./.blacktail.local ]; then
+  . ./.blacktail.local
+fi
+export BLACKTAIL_PRIMARY_USER
+
 export NIXPKGS_ALLOW_UNFREE=1
 
 echo "${YELLOW}Starting build...${NC}"
-nix --extra-experimental-features 'nix-command flakes' build .#$FLAKE_SYSTEM $@
+nix --extra-experimental-features 'nix-command flakes' build --impure .#$FLAKE_SYSTEM "$@"
 
 echo "${YELLOW}Switching to new generation...${NC}"
 # See https://github.com/nix-darwin/nix-darwin/issues/1457 on why we need sudo
-sudo ./result/sw/bin/darwin-rebuild switch --flake .#${SYSTEM_TYPE} $@
+sudo /usr/bin/env BLACKTAIL_PRIMARY_USER="$BLACKTAIL_PRIMARY_USER" \
+  ./result/sw/bin/darwin-rebuild switch --impure --flake .#${SYSTEM_TYPE} "$@"
 
 echo "${YELLOW}Cleaning up...${NC}"
 unlink ./result

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,14 @@
       self,
     }@inputs:
     let
-      user = "junr03";
+      localPrimaryUser = builtins.getEnv "BLACKTAIL_PRIMARY_USER";
+      primaryUser =
+        if localPrimaryUser == "" then
+          "junr03"
+        else if builtins.match "[a-zA-Z_][a-zA-Z0-9._-]*" localPrimaryUser != null then
+          localPrimaryUser
+        else
+          throw "BLACKTAIL_PRIMARY_USER must be a valid macOS short username";
       darwinSystems = [ "aarch64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs darwinSystems f;
       devShell =
@@ -97,7 +104,9 @@
         system:
         darwin.lib.darwinSystem {
           inherit system;
-          specialArgs = inputs;
+          specialArgs = inputs // {
+            inherit primaryUser;
+          };
           modules = [
             {
               nixpkgs.overlays = [
@@ -110,7 +119,7 @@
             nix-homebrew.darwinModules.nix-homebrew
             {
               nix-homebrew = {
-                inherit user;
+                user = primaryUser;
                 enable = true;
                 taps = {
                   "homebrew/homebrew-core" = homebrew-core;

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -3,10 +3,11 @@
   pkgs,
   lib,
   home-manager,
+  primaryUser,
   ...
 }:
 let
-  user = "junr03";
+  user = primaryUser;
   name = "Jose Ulises Nino Rivera";
   email = "junr03@users.noreply.github.com";
   userFiles = import ./files.nix { inherit user config pkgs; };

--- a/modules/host.nix
+++ b/modules/host.nix
@@ -2,10 +2,11 @@
   gallatin,
   config,
   pkgs,
+  primaryUser,
   ...
 }:
 let
-  user = "junr03";
+  user = primaryUser;
 in
 {
   imports = [


### PR DESCRIPTION
## Summary

- Read `BLACKTAIL_PRIMARY_USER` during local Nix evaluation and pass it to nix-darwin, Home Manager, and nix-homebrew.
- Load the Git-ignored `.blacktail.local` file in the build commands and preserve the username through the privileged rebuild.
- Add an installation step that records the current macOS short username before the first build.

## Why

Blacktail hardcoded `junr03` in the flake and two modules. A Mac with a different primary account would target the wrong user, home directory, and Homebrew owner.

## User impact

New users now create their local configuration during installation:

```sh
printf 'BLACKTAIL_PRIMARY_USER=%s\n' "$(id -un)" > .blacktail.local
```

Pure and CI evaluations keep the existing `junr03` default when no local override is present.

## Validation

- `nix flake check --print-build-logs --no-update-lock-file`
- Built `.#darwinConfigurations.aarch64-darwin.system` with `BLACKTAIL_PRIMARY_USER=jose.rivera`, `--impure`, and `--no-link`
- `pre-commit run --all-files`
- `sh -n apps/build apps/build-switch`
- `nixfmt --check flake.nix modules/host.nix modules/home-manager.nix`