### PR TITLE
Back up files during Home Manager adoption

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -48,6 +48,8 @@ in
 
   # Enable home-manager
   home-manager = {
+    # Preserve pre-existing files while they transition to Home Manager ownership.
+    backupFileExtension = "before-nix";
     useGlobalPkgs = true;
     users.${user} =
       {


### PR DESCRIPTION
## Summary

- Configure Home Manager to move pre-existing unmanaged files to a `.before-nix` backup before installing managed versions.
- Allow the current shell, VS Code, SSH, and public-key files to transition to Nix management without data loss.

## Why

The first activation currently stops during Home Manager's target check because these files already exist. The backup policy preserves each original in place and lets the activation install the Nix-managed files.

## Validation

- `nixfmt --check modules/home-manager.nix`
- `git diff --check`
- `BLACKTAIL_PRIMARY_USER=junr03 nix build --impure --no-link .#darwinConfigurations.aarch64-darwin.system`