### PR TITLE
Use Homebrew uninstall cleanup

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -26,7 +26,7 @@ in
 
     onActivation = {
       autoUpdate = false;
-      cleanup = "check";
+      cleanup = "uninstall";
       upgrade = true;
     };
 


### PR DESCRIPTION
## What changed

Set `homebrew.onActivation.cleanup` to `"uninstall"`.

## Why

nix-darwin will remove Homebrew formulae, casks, and taps that are not in its generated Brewfile during activation. This makes the declared configuration the source of truth while using normal Homebrew uninstall behavior for casks.

## Validation

- `nix develop -c pre-commit run --all-files`
- `nix flake check --all-systems --print-build-logs`
- `nix run .#build`