### PR TITLE
Add Okta Verify to managed apps

### DIFF
--- a/modules/casks.nix
+++ b/modules/casks.nix
@@ -7,6 +7,7 @@ _: [
   "ghostty"
   "google-drive"
   "obsidian"
+  "okta-verify"
   "postico"
   "raycast"
   "slack"


### PR DESCRIPTION
## Summary

Add the Okta Verify Homebrew cask to the managed macOS applications.

## Validation

- `git diff --check`
- `nix run .#build`