### PR TITLE
Add Infuse and 1Password Safari

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -42,6 +42,8 @@ in
     # This message is safe to ignore.
 
     masApps = {
+      "1password-for-safari" = 1569813296;
+      "infuse" = 1136220934;
       "photomator" = 1444636541;
     };
   };


### PR DESCRIPTION
## What changed

Added Infuse and 1Password for Safari to the declared Mac App Store apps.

## Why

The Homebrew activation cleanup removes undeclared Mac App Store apps. These two apps should be preserved and installed by the configuration.

## Validation

- `nix develop -c pre-commit run --all-files`
- `nix flake check --all-systems --print-build-logs`
- `nix run .#build`
